### PR TITLE
Fix mobile menu hide selector

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -36,9 +36,9 @@ $(function() {
 	}
 	function re_size () {
 		if ($( window ).width() <= 991) {
-			$('.nav li').on('click', function () {
-			$('.#menu ul').css({"display":"none"});
-			});
+                        $('.nav li').on('click', function () {
+                        $('#menu ul').css({"display":"none"});
+                        });
 	
 			/* ------------bannre button margin ------------- */
 			$('.cd-intro').children('button').removeClass('mt_30').addClass('mt_20');


### PR DESCRIPTION
## Summary
- fix menu selector in `re_size()` so mobile menu hides correctly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688d599dffc48328af4fcd4a6c7d3de0