### PR TITLE
Fix menu hide selector in re_size()

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -37,7 +37,7 @@ $(function() {
 	function re_size () {
 		if ($( window ).width() <= 991) {
                         $('.nav li').on('click', function () {
-                        $('#menu ul').css({"display":"none"});
+                        $('#menu ul').hide();
                         });
 	
 			/* ------------bannre button margin ------------- */


### PR DESCRIPTION
## Summary
- ensure clicking nav links hides the menu on smaller screens

## Testing
- `grep -n "re_size" -n js/custom.js`

------
https://chatgpt.com/codex/tasks/task_e_688d5b7b7934832880ff1706ecaf8cb7