### PR TITLE
Add Jest test for mail regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "sanketmuchhala.github.io",
+  "version": "1.0.0",
+  "description": "This is my personal portfolio website developed using HTML,CSS,JS.",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/mail.test.js
+++ b/tests/mail.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+
+const mailJs = fs.readFileSync(path.join(__dirname, '..', 'js', 'mail.js'), 'utf8');
+const regexMatch = mailJs.match(/var email_reg = (\/[^;]+\/);/);
+if (!regexMatch) throw new Error('email_reg regex not found');
+const emailRegex = eval(regexMatch[1]);
+
+describe('email regex from mail.js', () => {
+  const valid = [
+    'user@example.com',
+    'first.last@example.co.uk',
+    'user123@test-domain.io',
+  ];
+  const invalid = [
+    'plainaddress',
+    'missing@domain',
+    'user@.com',
+    'user@domain..com',
+  ];
+
+  test('accepts valid addresses', () => {
+    for (const e of valid) {
+      expect(emailRegex.test(e)).toBe(true);
+    }
+  });
+
+  test('rejects invalid addresses', () => {
+    for (const e of invalid) {
+      expect(emailRegex.test(e)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add npm `package.json` with Jest configured
- test email regex in `js/mail.js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d5b7d59a0832889f89b26a720c405